### PR TITLE
fix: improve chart customizability

### DIFF
--- a/charts/vault-instance/templates/cr.yaml
+++ b/charts/vault-instance/templates/cr.yaml
@@ -3,9 +3,9 @@ kind: "Vault"
 metadata:
   name: "vault"
 spec:
-  size: 1
-  image: vault:1.3.1
-  bankVaultsImage: banzaicloud/bank-vaults:master
+  size: {{ .Values.size }}
+  image: {{ .Values.image }}
+  bankVaultsImage: {{ .Values.bankVaultsImage }}
 
   # Common annotations for all created resources
   annotations:
@@ -64,6 +64,7 @@ spec:
   existingTlsSecretName: '{{ .Values.existingTlsSecretName }}'
 {{- end }}
 
+{{- if .Values.ingress.enabled }}
   # Request an Ingress controller with the default configuration
   ingress:
     # Specify Ingress object annotations here, if TLS is enabled (which is by default)
@@ -79,6 +80,7 @@ spec:
     spec:
 {{- if .Values.ingress.spec }}
 {{ toYaml .Values.ingress.spec | indent 6 }}
+{{- end }}
 {{- end }}
 
   # Use local disk to store Vault file data, see config section.
@@ -205,4 +207,4 @@ spec:
       value: "/vault/file"
 
   # Marks presence of Istio, which influences things like port namings
-  istioEnabled: false
+  istioEnabled: {{ .Values.istio.enabled }}

--- a/charts/vault-instance/values.yaml
+++ b/charts/vault-instance/values.yaml
@@ -1,5 +1,11 @@
+bankVaultsImage: banzaicloud/bank-vaults:master
+
 existingTlsSecretName: ""
+
+image: vault:1.3.1
+
 ingress:
+  enabled: true
   annotations: {}
   spec: 
     rules:
@@ -10,3 +16,8 @@ ingress:
               serviceName: vault
               servicePort: 8200
             path: /
+
+istio:
+  enabled: false
+
+size: 1


### PR DESCRIPTION
Was looking to switch to istio and found a bunch of the values I needed to change were hardcoded. This just moves some hardcoded values into `values.yaml` and allows you to enable or disable ingress.