### PR TITLE
Update ingress definition for k8s 1.21

### DIFF
--- a/charts/vault-instance/values.yaml
+++ b/charts/vault-instance/values.yaml
@@ -13,9 +13,12 @@ ingress:
         http:
           paths:
           - backend:
-              serviceName: vault
-              servicePort: 8200
+              service:
+                name: vault
+                port:
+                  number: 8200
             path: /
+            pathType: ImplementationSpecific
 
 istio:
   enabled: false


### PR DESCRIPTION
Update ingress rules according to https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122