### PR TITLE
fix: switch to ghcr to support arm platform

### DIFF
--- a/charts/vault-instance/values.yaml
+++ b/charts/vault-instance/values.yaml
@@ -1,4 +1,4 @@
-bankVaultsImage: banzaicloud/bank-vaults:1.15.3
+bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:1.15.3
 
 existingTlsSecretName: ""
 


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

dockerhub images of banzai vault don't support arm, but ghcr registry images support it.