### PR TITLE
upgrade vault and use default bank vault image if not defined

### DIFF
--- a/charts/vault-instance/templates/cr.yaml
+++ b/charts/vault-instance/templates/cr.yaml
@@ -5,8 +5,9 @@ metadata:
 spec:
   size: {{ .Values.size }}
   image: {{ .Values.image }}
-  bankVaultsImage: {{ .Values.bankVaultsImage }}
-
+{{ with .Values.bankVaultsImage }}
+  bankVaultsImage: {{ . }}
+{{ end }}
   # Common annotations for all created resources
   annotations:
     common/annotation: "true"

--- a/charts/vault-instance/values.yaml
+++ b/charts/vault-instance/values.yaml
@@ -1,8 +1,6 @@
-bankVaultsImage: ghcr.io/banzaicloud/bank-vaults:1.15.3
-
 existingTlsSecretName: ""
 
-image: vault:1.10.3
+image: vault:1.17.6
 
 ingress:
   enabled: true


### PR DESCRIPTION
This is a part of the fix to jenkins-x/jx#8688